### PR TITLE
Fix operand order in assert statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ $exported = Exporter::export($value);
 
 file_put_contents('code.php', '<?php return '.$exported.';');
 
-\assert(require_once 'code.php' == $value);
+\assert($value == require_once 'code.php');
 ```


### PR DESCRIPTION
Currently it throws the following PHP warning.

> PHP Warning:  require_once(/var/www/exporter): Failed to open stream: